### PR TITLE
feat: auto-complete dlcs game time and hide it

### DIFF
--- a/finishedgames/catalogsources/adapters/base_adapter.py
+++ b/finishedgames/catalogsources/adapters/base_adapter.py
@@ -2,7 +2,7 @@ from abc import ABC, abstractmethod
 from typing import Any, List, Tuple
 
 from catalogsources.models import FetchedGame, FetchedPlatform
-from core.models import UNKNOWN_PUBLISH_DATE
+from core.constants import UNKNOWN_PUBLISH_DATE
 from django.core.management.base import OutputWrapper
 from django.core.management.color import Style
 

--- a/finishedgames/catalogsources/admin/forms.py
+++ b/finishedgames/catalogsources/admin/forms.py
@@ -1,5 +1,6 @@
 from catalogsources.admin.form_fields import SimpleArrayField
-from core.models import UNKNOWN_PUBLISH_DATE, Game, Platform
+from core.constants import UNKNOWN_PUBLISH_DATE
+from core.models import Game, Platform
 from django import forms
 from django.core.validators import MaxValueValidator, MinValueValidator
 from django.db.models.functions import Lower

--- a/finishedgames/catalogsources/management/commands/import_fetched_games_without_fg_game.py
+++ b/finishedgames/catalogsources/management/commands/import_fetched_games_without_fg_game.py
@@ -2,7 +2,7 @@ from typing import Any, Dict, cast
 
 from catalogsources.managers import GameImportSaveError, ImportManager
 from catalogsources.models import FetchedGame
-from core.models import UNKNOWN_PUBLISH_DATE
+from core.constants import UNKNOWN_PUBLISH_DATE
 from django.conf import settings
 from django.core.management.base import BaseCommand, CommandParser
 from finishedgames import constants

--- a/finishedgames/catalogsources/managers.py
+++ b/finishedgames/catalogsources/managers.py
@@ -3,7 +3,8 @@ from typing import List, Optional, Tuple, cast
 
 from catalogsources.helpers import clean_string_field
 from catalogsources.models import FetchedGame, FetchedPlatform
-from core.models import UNKNOWN_PUBLISH_DATE, Game, Platform
+from core.constants import UNKNOWN_PUBLISH_DATE
+from core.models import Game, Platform
 from django.conf import settings
 
 from finishedgames import constants

--- a/finishedgames/core/constants.py
+++ b/finishedgames/core/constants.py
@@ -1,0 +1,7 @@
+URLS_KEY_VALUE_GLUE = "||"
+URLS_ITEMS_GLUE = "@@"
+
+# Games that have no date at a source catalog get the minimum accepted date (we always need a date)
+UNKNOWN_PUBLISH_DATE = 1970
+
+DLC_DEFAULT_MINUTES_PLAYED = 15

--- a/finishedgames/core/managers.py
+++ b/finishedgames/core/managers.py
@@ -1,3 +1,4 @@
+from core.constants import DLC_DEFAULT_MINUTES_PLAYED
 from core.models import UserGame, WishlistedUserGame
 from django.conf import settings
 
@@ -23,9 +24,13 @@ class CatalogManager:
     def mark_as_finished(user: settings.AUTH_USER_MODEL, game_id: int, platform_id: int, year_finished: int) -> None:
         CatalogManager.unmark_as_abandoned(user=user, game_id=game_id, platform_id=platform_id)
 
-        user_game = UserGame.objects.filter(user=user, game_id=game_id, platform_id=platform_id).get()
+        user_game = UserGame.objects.select_related("game").filter(user=user, game_id=game_id, platform_id=platform_id).get()
         user_game.year_finished = year_finished
-        user_game.save(update_fields=["year_finished"])
+        update_fields = ["year_finished"]
+        if user_game.game.dlc_or_expansion and user_game.minutes_played == 0:
+            user_game.minutes_played = DLC_DEFAULT_MINUTES_PLAYED
+            update_fields.append("minutes_played")
+        user_game.save(update_fields=update_fields)
 
 
     @staticmethod

--- a/finishedgames/core/models.py
+++ b/finishedgames/core/models.py
@@ -1,17 +1,12 @@
 from typing import Any, Dict, cast
 
+from core.constants import UNKNOWN_PUBLISH_DATE, URLS_ITEMS_GLUE, URLS_KEY_VALUE_GLUE
 from core.helpers import generic_id as generic_id_helper
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.core.validators import MaxValueValidator, MinValueValidator
 from django.db import models
 from django.db.models.functions import Lower
-
-URLS_KEY_VALUE_GLUE = "||"
-URLS_ITEMS_GLUE = "@@"
-
-# Games that have no date at a source catalog get the minimum accepted date (we always need a date)
-UNKNOWN_PUBLISH_DATE = 1970
 
 
 class BasePlatform(models.Model):

--- a/finishedgames/core/test/test_managers.py
+++ b/finishedgames/core/test/test_managers.py
@@ -1,3 +1,4 @@
+from core.constants import DLC_DEFAULT_MINUTES_PLAYED
 from core.managers import CatalogManager
 from core.models import UserGame, WishlistedUserGame
 from core.test.tests_helpers import create_game, create_platform, create_user
@@ -207,3 +208,38 @@ class UserGameTests(TestCase):
         self.user_game.refresh_from_db()
         self.assertFalse(self.user_game.abandoned)
         self.assertEqual(self.user_game.year_finished, None)
+
+    def test_mark_as_finished_dlc_with_zero_time_sets_default_time(self) -> None:
+        parent_game = create_game(platforms=[self.platform])
+        dlc_game = create_game(platforms=[self.platform], dlc_or_expansion=True, parent_game=parent_game)
+        dlc_user_game = UserGame(user_id=self.user.id, game_id=dlc_game.id, platform_id=self.platform.id)
+        dlc_user_game.save()
+        an_irrelevant_year = 2024
+
+        CatalogManager.mark_as_finished(self.user, dlc_game.id, self.platform.id, an_irrelevant_year)
+
+        dlc_user_game.refresh_from_db()
+        self.assertTrue(dlc_user_game.finished)
+        self.assertEqual(dlc_user_game.minutes_played, DLC_DEFAULT_MINUTES_PLAYED)
+
+    def test_mark_as_finished_dlc_with_nonzero_time_keeps_time(self) -> None:
+        parent_game = create_game(platforms=[self.platform])
+        dlc_game = create_game(platforms=[self.platform], dlc_or_expansion=True, parent_game=parent_game)
+        dlc_user_game = UserGame(user_id=self.user.id, game_id=dlc_game.id, platform_id=self.platform.id, minutes_played=5)
+        dlc_user_game.save()
+        an_irrelevant_year = 2024
+
+        CatalogManager.mark_as_finished(self.user, dlc_game.id, self.platform.id, an_irrelevant_year)
+
+        dlc_user_game.refresh_from_db()
+        self.assertTrue(dlc_user_game.finished)
+        self.assertEqual(dlc_user_game.minutes_played, 5)
+
+    def test_mark_as_finished_non_dlc_with_zero_time_stays_zero(self) -> None:
+        an_irrelevant_year = 2024
+
+        CatalogManager.mark_as_finished(self.user, self.game.id, self.platform.id, an_irrelevant_year)
+
+        self.user_game.refresh_from_db()
+        self.assertTrue(self.user_game.finished)
+        self.assertEqual(self.user_game.minutes_played, 0)

--- a/finishedgames/web/templates/game_details.html
+++ b/finishedgames/web/templates/game_details.html
@@ -46,7 +46,7 @@
                     {% render_actions user game.id platform.id authenticated_user_catalog %}
                     {% with user_game=user_games_by_platform|get_item:platform.id %}
                         {% if user_game %}
-                            {% render_game_time user user_game.id user_game.minutes_played %}
+                            {% render_game_time user user_game.id user_game.minutes_played game.dlc_or_expansion %}
                         {% else %}
                             <td> </td>
                         {% endif %}

--- a/finishedgames/web/templates/templatetags/game_time.html
+++ b/finishedgames/web/templates/templatetags/game_time.html
@@ -1,3 +1,6 @@
+{% if is_dlc %}
+<td class="is-centered">n/a (DLC)</td>
+{% else %}
 <td class="is-centered">
     <form action="{% url 'user_game_time' user.get_username %}" method="post" style="display: inline;">
         {% csrf_token %}
@@ -12,3 +15,4 @@
         /> mins
     </form>
 </td>
+{% endif %}

--- a/finishedgames/web/templates/user/abandoned_games.html
+++ b/finishedgames/web/templates/user/abandoned_games.html
@@ -50,7 +50,7 @@
             {% if user.is_authenticated %}
                 {% render_actions user item.game.id item.platform.id authenticated_user_catalog %}
                 {% if constants.KEY_FIELD_GAME_TIME in enabled_fields %}
-                    {% render_game_time user item.id item.minutes_played %}
+                    {% render_game_time user item.id item.minutes_played item.game.dlc_or_expansion %}
                 {% endif %}
             {% endif %}
         </tr>

--- a/finishedgames/web/templates/user/currently_playing_games.html
+++ b/finishedgames/web/templates/user/currently_playing_games.html
@@ -57,7 +57,7 @@
             {% if user.is_authenticated %}
                 {% render_actions user item.game.id item.platform.id authenticated_user_catalog %}
                 {% if constants.KEY_FIELD_GAME_TIME in enabled_fields %}
-                    {% render_game_time user item.id item.minutes_played %}
+                    {% render_game_time user item.id item.minutes_played item.game.dlc_or_expansion %}
                 {% endif %}
             {% endif %}
         </tr>

--- a/finishedgames/web/templates/user/finished_games.html
+++ b/finishedgames/web/templates/user/finished_games.html
@@ -60,7 +60,7 @@
             {% if user.is_authenticated %}
                 {% render_actions user item.game.id item.platform.id authenticated_user_catalog %}
                 {% if constants.KEY_FIELD_GAME_TIME in enabled_fields %}
-                    {% render_game_time user item.id item.minutes_played %}
+                    {% render_game_time user item.id item.minutes_played item.game.dlc_or_expansion %}
                 {% endif %}
             {% endif %}
         </tr>

--- a/finishedgames/web/templates/user/games.html
+++ b/finishedgames/web/templates/user/games.html
@@ -50,7 +50,7 @@
                 {% if user.is_authenticated %}
                     {% render_actions user item.game.id item.platform.id authenticated_user_catalog %}
                     {% if constants.KEY_FIELD_GAME_TIME in enabled_fields %}
-                        {% render_game_time user item.id item.minutes_played %}
+                        {% render_game_time user item.id item.minutes_played item.game.dlc_or_expansion %}
                     {% endif %}
                 {% endif %}
             </tr>

--- a/finishedgames/web/templates/user/games_by_platform.html
+++ b/finishedgames/web/templates/user/games_by_platform.html
@@ -47,7 +47,7 @@
                 {% if user.is_authenticated %}
                     {% render_actions user item.game.id platform.id authenticated_user_catalog %}
                     {% if constants.KEY_FIELD_GAME_TIME in enabled_fields %}
-                        {% render_game_time user item.id item.minutes_played %}
+                        {% render_game_time user item.id item.minutes_played item.game.dlc_or_expansion %}
                     {% endif %}
                 {% endif %}
             </tr>

--- a/finishedgames/web/templates/user/pending_games.html
+++ b/finishedgames/web/templates/user/pending_games.html
@@ -56,7 +56,7 @@
             {% if user.is_authenticated %}
                 {% render_actions user item.game.id item.platform.id authenticated_user_catalog %}
                 {% if constants.KEY_FIELD_GAME_TIME in enabled_fields %}
-                    {% render_game_time user item.id item.minutes_played %}
+                    {% render_game_time user item.id item.minutes_played item.game.dlc_or_expansion %}
                 {% endif %}
             {% endif %}
         </tr>

--- a/finishedgames/web/templatetags/web_extras.py
+++ b/finishedgames/web/templatetags/web_extras.py
@@ -39,11 +39,12 @@ def render_actions(
 
 
 @register.inclusion_tag("templatetags/game_time.html")
-def render_game_time(user: settings.AUTH_USER_MODEL, user_game_id: int, game_time: int) -> Dict:
+def render_game_time(user: settings.AUTH_USER_MODEL, user_game_id: int, game_time: int, is_dlc: bool = False) -> Dict:
     return {
         "user": user,
         "user_game_id": user_game_id,
         "game_time": game_time,
+        "is_dlc": is_dlc,
         "constants": constants,
     }
 


### PR DESCRIPTION
Auto-set gameplay for DLCs (to 15 minutes), as most games will count this as part of the main game. Just in case, only sets it if the gameplay time is 0.

Also, hiding the box to enter gameplay time for DLCs, and the value.